### PR TITLE
Update Makefile and scripts for Amoy testnet support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ simulate :; npm run simulate
 
 getweth :; cast call TOKEN_BRIDGE_ADDRESS "getWeth()" --rpc-url ${SEPOLIA_RPC_URL} | cut -c 27- | xargs printf "0x%s\n" | cast --to-checksum-address 
 
-setSupportedChain-mumbai :; cast send TOKEN_BRIDGE_ADDRESS "setSupportedChain(uint64,bool)" 16015286601757825753 true  --rpc-url ${MUMBAI_RPC_URL} --account XXX --sender YYY
-setSupportedChain-sepolia :; cast send TOKEN_BRIDGE_ADDRESS "setSupportedChain(uint64,bool)" 12532609583862916517 true --rpc-url ${SEPOLIA_RPC_URL} --account XXX --sender YYY
+# As of April 2024 , Mumbaiis deprecated and new testnet AMOY is available
+setSupportedChain-amoy :; cast send TOKEN_BRIDGE_ADDRESS "setSupportedChain(uint64,bool)" 16015286601757825753 true  --rpc-url ${AMOY_RPC_URL} --account XXX --sender YYY
+setSupportedChain-sepolia :; cast send TOKEN_BRIDGE_ADDRESS "setSupportedChain(uint64,bool)" 16281711391670634445 true --rpc-url ${SEPOLIA_RPC_URL} --account XXX --sender YYY
 
 # Multi-chain deployment doesn't work with account/sender yet :/ 
 deploy-bridges :; forge script script/DeployTokenBridges.s.sol --private-key ${PRIVATE_KEY} --verify --broadcast

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,11 +14,11 @@ solc = "0.8.25"
 [etherscan]
 polygon = { key = "${POLYGONSCAN_API_KEY}" }
 sepolia = { key = "${ETHERSCAN_API_KEY}" }
-mumbai = { key = "${POLYGONSCAN_API_KEY}" }
+amoy = { key = "${POLYGONSCAN_API_KEY}" }
 
 [rpc_endpoints]
 polygon = "${POLYGON_RPC_URL}"
-mumbai = "${MUMBAI_RPC_URL}"
+amoy = "${AMOY_RPC_URL}"
 sepolia = "${SEPOLIA_RPC_URL}"
 
 [invariant]

--- a/script/DeployHomeChainContracts.s.sol
+++ b/script/DeployHomeChainContracts.s.sol
@@ -7,7 +7,7 @@ import { TokenBridge } from "../src/ccip/TokenBridge.sol";
 import { WETH } from "../src/ccip/WETH.sol";
 
 contract DeployHomeChainContracts is Script {
-    uint64 constant HOME_BASE_CHAIN_SELECTOR = 12_532_609_583_862_916_517; // This is mumbai
+    uint64 constant HOME_BASE_CHAIN_SELECTOR = 16_281_711_391_670_634_445; // This is amoy
 
     function run() external {
         // Get params

--- a/script/DeployNewChainContracts.s.sol
+++ b/script/DeployNewChainContracts.s.sol
@@ -6,7 +6,7 @@ import { HelperConfig } from "./HelperConfig.sol";
 import { TokenBridge } from "../src/ccip/TokenBridge.sol";
 
 contract DeployNewChainContracts is Script {
-    uint64 constant HOME_BASE_CHAIN_SELECTOR = 12_532_609_583_862_916_517; // This is mumbai
+    uint64 constant HOME_BASE_CHAIN_SELECTOR = 16_281_711_391_670_634_445; // This is amoy
 
     function run() external {
         // Get params

--- a/script/DeployTokenBridges.s.sol
+++ b/script/DeployTokenBridges.s.sol
@@ -6,8 +6,8 @@ import { HelperConfig } from "./HelperConfig.sol";
 import { TokenBridge } from "../src/ccip/TokenBridge.sol";
 import { WETH } from "../src/ccip/WETH.sol";
 
-// Mumbai WETH: 0x089dc24123e0A27d44282A1CcC2fd815989E3300
-// Mumbai TokenBridge: 0xa9aCB9825F3A152c9dA7386D711e4a50a066a87D
+// Amoy WETH: 0x089dc24123e0A27d44282A1CcC2fd815989E3300
+// Amoy TokenBridge: 0xa9aCB9825F3A152c9dA7386D711e4a50a066a87D
 // Sepolia TokenBridge: 0x8Bd94F5E6024BBADB026E80D453f5F8fAB2bC5Cc
 // Sepolia WETH: 0xB7E4d665c3f4ed24Da355F55E6c6046d9C2E79d9
 
@@ -16,16 +16,16 @@ contract DeployHomeChainContracts is Script {
         // Get params
 
         // Actually deploy
-        vm.createSelectFork(vm.rpcUrl("mumbai"));
-        // Mumbai is home base
-        (address mumbaiLinkToken, address mumbaiCcipRouter, uint64 mumbaiCcipChainSelector) =
+        vm.createSelectFork(vm.rpcUrl("amoy"));
+        // Amoy is home base
+        (address amoyLinkToken, address amoyCcipRouter, uint64 amoyCcipChainSelector) =
             getTokenBridgeRequirements();
-        uint64 homeBaseChainSelector = mumbaiCcipChainSelector;
+        uint64 homeBaseChainSelector = amoyCcipChainSelector;
 
         vm.startBroadcast();
         WETH weth = deployWETH();
         TokenBridge tBridge = deployTokenBridge(
-            mumbaiCcipRouter, mumbaiLinkToken, address(weth), homeBaseChainSelector, mumbaiCcipChainSelector
+            amoyCcipRouter, amoyLinkToken, address(weth), homeBaseChainSelector, amoyCcipChainSelector
         );
         vm.stopBroadcast();
 
@@ -36,7 +36,7 @@ contract DeployHomeChainContracts is Script {
         deployTokenBridge(sepCcipRouter, sepLinkToken, payable(address(0)), homeBaseChainSelector, sepChainSelector);
         vm.stopBroadcast();
 
-        vm.createSelectFork(vm.rpcUrl("mumbai"));
+        vm.createSelectFork(vm.rpcUrl("amoy"));
         vm.startBroadcast();
         tBridge.setSupportedChain(sepChainSelector, true);
         vm.stopBroadcast();

--- a/script/DeployTokenBridges.s.sol
+++ b/script/DeployTokenBridges.s.sol
@@ -6,6 +6,7 @@ import { HelperConfig } from "./HelperConfig.sol";
 import { TokenBridge } from "../src/ccip/TokenBridge.sol";
 import { WETH } from "../src/ccip/WETH.sol";
 
+// Deploy the contracts using the script
 // Amoy WETH: 0x089dc24123e0A27d44282A1CcC2fd815989E3300
 // Amoy TokenBridge: 0xa9aCB9825F3A152c9dA7386D711e4a50a066a87D
 // Sepolia TokenBridge: 0x8Bd94F5E6024BBADB026E80D453f5F8fAB2bC5Cc

--- a/script/HelperConfig.sol
+++ b/script/HelperConfig.sol
@@ -46,7 +46,7 @@ contract HelperConfig {
 
     constructor() {
         chainIdToNetworkConfig[137] = getPolygonConfig();
-        chainIdToNetworkConfig[80_001] = getMumbaiConfig();
+        chainIdToNetworkConfig[80_002] = getAmoyConfig();
         chainIdToNetworkConfig[31_337] = _setupAnvilConfig();
         activeNetworkConfig = chainIdToNetworkConfig[block.chainid];
     }
@@ -71,19 +71,19 @@ contract HelperConfig {
         // https://alpaca.markets/support/crypto-wallet-faq
     }
 
-    function getMumbaiConfig() internal pure returns (NetworkConfig memory config) {
+    function getAmoyConfig() internal pure returns (NetworkConfig memory config) {
         config = NetworkConfig({
-            tslaPriceFeed: 0x1C2252aeeD50e0c9B64bDfF2735Ee3C932F5C408, // this is LINK / USD but it'll work fine
-            usdcPriceFeed: 0x572dDec9087154dC5dfBB1546Bb62713147e0Ab0,
-            ethUsdPriceFeed: 0x0715A7794a1dc8e42615F059dD6e406A6594651A,
-            functionsRouter: 0x6E2dc0F9DB014aE19888F539E59285D2Ea04244C,
-            donId: 0x66756e2d706f6c79676f6e2d6d756d6261692d31000000000000000000000000,
-            subId: 1396,
-            // USDC on Mumbai
-            redemptionCoin: 0xe6b8a5CF854791412c1f6EFC7CAf629f5Df1c747,
-            linkToken: 0x326C977E6efc84E512bB9C30f76E30c160eD06FB,
-            ccipRouter: 0x1035CabC275068e0F4b745A29CEDf38E13aF41b1,
-            ccipChainSelector: 12_532_609_583_862_916_517,
+            tslaPriceFeed: 0xc2e2848e28B9fE430Ab44F55a8437a33802a219C, // this is LINK / USD but it'll work fine
+            usdcPriceFeed: 0x1b8739bB4CdF0089d07097A9Ae5Bd274b29C6F16,
+            ethUsdPriceFeed: 0xF0d50568e3A7e8259E16663972b11910F89BD8e7,
+            functionsRouter: 0xC22a79eBA640940ABB6dF0f7982cc119578E11De,
+            donId: 0x66756e2d706f6c79676f6e2d616d6f792d310000000000000000000000000000,
+            subId: 1396, // TODO
+            // USDC on Amoy
+            redemptionCoin: 0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582, 
+            linkToken: 0x0Fd9e8d3aF1aaee056EB9e802c3A762a667b1904,
+            ccipRouter: 0x9C32fCB86BF0f4a1A8921a9Fe46de3198bb884B2,
+            ccipChainSelector: 16_281_711_391_670_634_445,
             secretVersion: 0, // fill in!
             secretSlot: 0 // fill in!
          });
@@ -99,7 +99,7 @@ contract HelperConfig {
             functionsRouter: 0xb83E47C2bC239B3bf370bc41e1459A34b41238D0,
             donId: 0x66756e2d657468657265756d2d7365706f6c69612d3100000000000000000000,
             subId: 2274,
-            // USDC on Mumbai
+            // USDC on Sepolia
             redemptionCoin: 0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238,
             linkToken: 0x779877A7B0D9E8603169DdbD7836e478b4624789,
             ccipRouter: 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59,


### PR DESCRIPTION
This pull request includes several changes to update the codebase to replace the deprecated Mumbai testnet with the new Amoy testnet. The most important changes include updating the chain selectors, RPC URLs, and network configurations.

Updates to chain selectors and RPC URLs:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L42-R44): Replaced Mumbai references with Amoy in the `setSupportedChain` commands and updated the chain selector for Sepolia.
* [`foundry.toml`](diffhunk://#diff-bac743fe3d899998e32393af53af8cc7d28c89c3d7fabfa48b01361cf8d42d9bL17-R21): Replaced Mumbai RPC URL and API key references with Amoy.

Updates to deployment scripts:

* [`script/DeployHomeChainContracts.s.sol`](diffhunk://#diff-3ae5c3417e7ef4a6a3939a7eb054d1f0deb7fedb1e84843dde3706947fc55670L10-R10): Updated the chain selector for the home base chain from Mumbai to Amoy.
* [`script/DeployNewChainContracts.s.sol`](diffhunk://#diff-5bdcc645d83d3bad0c0d32e6897f6e898fe0ef7ea4d8f98ef67e6cfe113edf03L9-R9): Updated the chain selector for the home base chain from Mumbai to Amoy.
* [`script/DeployTokenBridges.s.sol`](diffhunk://#diff-0d794874a64e0c083fb4c5a6b8b47bbe25720d46adec54f88551606dd3ce97f8L9-R11): Updated deployment details and chain selectors from Mumbai to Amoy, including WETH and TokenBridge addresses. [[1]](diffhunk://#diff-0d794874a64e0c083fb4c5a6b8b47bbe25720d46adec54f88551606dd3ce97f8L9-R11) [[2]](diffhunk://#diff-0d794874a64e0c083fb4c5a6b8b47bbe25720d46adec54f88551606dd3ce97f8L19-R29) [[3]](diffhunk://#diff-0d794874a64e0c083fb4c5a6b8b47bbe25720d46adec54f88551606dd3ce97f8L39-R40)

Updates to network configuration:

* [`script/HelperConfig.sol`](diffhunk://#diff-53e637932bd465d56bb61c99357b8fea17215fd5816029053527a7d23695043fL49-R49): Replaced Mumbai network configuration with Amoy, including price feeds, router addresses, and chain selectors. [[1]](diffhunk://#diff-53e637932bd465d56bb61c99357b8fea17215fd5816029053527a7d23695043fL49-R49) [[2]](diffhunk://#diff-53e637932bd465d56bb61c99357b8fea17215fd5816029053527a7d23695043fL74-R86) [[3]](diffhunk://#diff-53e637932bd465d56bb61c99357b8fea17215fd5816029053527a7d23695043fL102-R102)
This pull request includes updates to replace the deprecated Mumbai testnet with the new Amoy testnet across various files. The changes ensure that the codebase is aligned with the new testnet requirements and configurations.

### Testnet Update:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L42-R44): Removed Mumbai testnet references and added Amoy testnet configurations for `setSupportedChain` commands.
* [`foundry.toml`](diffhunk://#diff-bac743fe3d899998e32393af53af8cc7d28c89c3d7fabfa48b01361cf8d42d9bL17-R21): Replaced Mumbai testnet configurations with Amoy testnet configurations.

### Chain Selector Update:

* [`script/DeployHomeChainContracts.s.sol`](diffhunk://#diff-3ae5c3417e7ef4a6a3939a7eb054d1f0deb7fedb1e84843dde3706947fc55670L10-R10): Updated the `HOME_BASE_CHAIN_SELECTOR` from Mumbai to Amoy.
* [`script/DeployNewChainContracts.s.sol`](diffhunk://#diff-5bdcc645d83d3bad0c0d32e6897f6e898fe0ef7ea4d8f98ef67e6cfe113edf03L9-R9): Changed the `HOME_BASE_CHAIN_SELECTOR` to use Amoy instead of Mumbai.
* [`script/DeployTokenBridges.s.sol`](diffhunk://#diff-0d794874a64e0c083fb4c5a6b8b47bbe25720d46adec54f88551606dd3ce97f8L9-R11): Updated the deployment script to use Amoy testnet configurations and chain selectors. [[1]](diffhunk://#diff-0d794874a64e0c083fb4c5a6b8b47bbe25720d46adec54f88551606dd3ce97f8L9-R11) [[2]](diffhunk://#diff-0d794874a64e0c083fb4c5a6b8b47bbe25720d46adec54f88551606dd3ce97f8L19-R29) [[3]](diffhunk://#diff-0d794874a64e0c083fb4c5a6b8b47bbe25720d46adec54f88551606dd3ce97f8L39-R40)

### Configuration Update:

* [`script/HelperConfig.sol`](diffhunk://#diff-53e637932bd465d56bb61c99357b8fea17215fd5816029053527a7d23695043fL49-R49): Replaced Mumbai network configuration with Amoy network configuration, including updated addresses for price feeds, tokens, and routers. [[1]](diffhunk://#diff-53e637932bd465d56bb61c99357b8fea17215fd5816029053527a7d23695043fL49-R49) [[2]](diffhunk://#diff-53e637932bd465d56bb61c99357b8fea17215fd5816029053527a7d23695043fL74-R86) [[3]](diffhunk://#diff-53e637932bd465d56bb61c99357b8fea17215fd5816029053527a7d23695043fL102-R102)