### PR TITLE
Fixed RWA_CONTRACT issue by adding setRedeemSource function

### DIFF
--- a/script/DeployTokenBridges.s.sol
+++ b/script/DeployTokenBridges.s.sol
@@ -19,8 +19,7 @@ contract DeployHomeChainContracts is Script {
         // Actually deploy
         vm.createSelectFork(vm.rpcUrl("amoy"));
         // Amoy is home base
-        (address amoyLinkToken, address amoyCcipRouter, uint64 amoyCcipChainSelector) =
-            getTokenBridgeRequirements();
+        (address amoyLinkToken, address amoyCcipRouter, uint64 amoyCcipChainSelector) = getTokenBridgeRequirements();
         uint64 homeBaseChainSelector = amoyCcipChainSelector;
 
         vm.startBroadcast();

--- a/script/HelperConfig.sol
+++ b/script/HelperConfig.sol
@@ -80,7 +80,7 @@ contract HelperConfig {
             donId: 0x66756e2d706f6c79676f6e2d616d6f792d310000000000000000000000000000,
             subId: 1396, // TODO
             // USDC on Amoy
-            redemptionCoin: 0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582, 
+            redemptionCoin: 0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582,
             linkToken: 0x0Fd9e8d3aF1aaee056EB9e802c3A762a667b1904,
             ccipRouter: 0x9C32fCB86BF0f4a1A8921a9Fe46de3198bb884B2,
             ccipChainSelector: 16_281_711_391_670_634_445,

--- a/src/dTSLA.sol
+++ b/src/dTSLA.sol
@@ -22,6 +22,7 @@ contract dTSLA is FunctionsClient, ConfirmedOwner, ERC20, Pausable {
     error dTSLA__NotEnoughCollateral();
     error dTSLA__BelowMinimumRedemption();
     error dTSLA__RedemptionFailed();
+    error dTSLA_RedeemSourceCannotBeEmpty();
 
     // Custom error type
     error UnexpectedRequestID(bytes32 requestId);
@@ -120,6 +121,13 @@ contract dTSLA is FunctionsClient, ConfirmedOwner, ERC20, Pausable {
 
     function setSecretSlot(uint8 secretSlot) external onlyOwner {
         s_secretSlot = secretSlot;
+    }
+
+    function setRedeemSource(string calldata newRedeemSource) external onlyOwner {
+        if (bytes(newRedeemSource).length == 0) {
+            revert dTSLA_RedeemSourceCannotBeEmpty();
+        }
+        s_redeemSource = newRedeemSource;
     }
 
     /**

--- a/src/libraries/OracleLib.sol
+++ b/src/libraries/OracleLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import { AggregatorV3Interface } from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
 /*
  * @title OracleLib

--- a/src/sTSLA.sol
+++ b/src/sTSLA.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {OracleLib, AggregatorV3Interface} from "./libraries/OracleLib.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { OracleLib, AggregatorV3Interface } from "./libraries/OracleLib.sol";
 
 /*
  * @dev the codebase will mint sTSLA based on the collateral 
@@ -65,7 +65,7 @@ contract sTSLA is ERC20 {
         }
         _burn(msg.sender, amountToRedeem);
         // External
-        (bool success,) = msg.sender.call{value: ethToReturn}("");
+        (bool success,) = msg.sender.call{ value: ethToReturn }("");
         if (!success) {
             revert("sTSLA_feeds: transfer failed");
         }
@@ -107,7 +107,10 @@ contract sTSLA is ERC20 {
         totalCollateralValueUsd = getUsdAmountFromEth(totalCollateralEth);
     }
 
-    function _calculateHealthFactor(uint256 tslaMintedValueUsd, uint256 collateralValueUsd)
+    function _calculateHealthFactor(
+        uint256 tslaMintedValueUsd,
+        uint256 collateralValueUsd
+    )
         internal
         pure
         returns (uint256)

--- a/src/test/mocks/MockV3Aggregator.sol
+++ b/src/test/mocks/MockV3Aggregator.sol
@@ -35,12 +35,7 @@ contract MockV3Aggregator {
         getStartedAt[latestRound] = block.timestamp;
     }
 
-    function updateRoundData(
-        uint80 _roundId,
-        int256 _answer,
-        uint256 _timestamp,
-        uint256 _startedAt
-    ) public {
+    function updateRoundData(uint80 _roundId, int256 _answer, uint256 _timestamp, uint256 _startedAt) public {
         latestRound = _roundId;
         latestAnswer = _answer;
         latestTimestamp = _timestamp;
@@ -52,33 +47,15 @@ contract MockV3Aggregator {
     function getRoundData(uint80 _roundId)
         external
         view
-        returns (
-            uint80 roundId,
-            int256 answer,
-            uint256 startedAt,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        )
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
-        return (
-            _roundId,
-            getAnswer[_roundId],
-            getStartedAt[_roundId],
-            getTimestamp[_roundId],
-            _roundId
-        );
+        return (_roundId, getAnswer[_roundId], getStartedAt[_roundId], getTimestamp[_roundId], _roundId);
     }
 
     function latestRoundData()
         external
         view
-        returns (
-            uint80 roundId,
-            int256 answer,
-            uint256 startedAt,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        )
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
         return (
             uint80(latestRound),

--- a/test/unit/dTSLATest.t.sol
+++ b/test/unit/dTSLATest.t.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import {Base_Test} from "../Base_Test.t.sol";
+import { Base_Test } from "../Base_Test.t.sol";
 
-contract dTSLATest is Base_Test {}
+contract dTSLATest is Base_Test { }


### PR DESCRIPTION
### **Function: `setRedeemSource`**  

This function is responsible for updating the redeem source in the dTSLA Contract.  

#### **Key Features:**  
- **`onlyOwner` Modifier:** Ensures that only the contract owner (or an authorized admin) can update the redeem source.  
- **Input Validation:** Uses an `if` statement and `revert` with a custom error (`dTSLA_RedeemSourceCannotBeEmpty`) to enforce that `newRedeemSource` cannot be an empty string.  
- **State Update:** Assigns `newRedeemSource` to `s_redeemSource`, which is later used in `sendRedeemRequest`.  


This update enhances **consistency and gas efficiency  in the contract.