### PR TITLE
Fix: Update Collateral Mapping in redeemAndBurn Function

### DIFF
--- a/src/sTSLA.sol
+++ b/src/sTSLA.sol
@@ -54,14 +54,14 @@ contract sTSLA is ERC20 {
         // No external interactions
     }
 
-    function redeemAndBurn(uint256 amountToRedeem) external {git add contracts/sTSLA.sol
+    function redeemAndBurn(uint256 amountToRedeem) external {
 
         // Checks / Effects
         uint256 valueRedeemed = getUsdAmountFromTsla(amountToRedeem);
         uint256 ethToReturn = getEthAmountFromUsd(valueRedeemed);
 
         s_tslaMintedPerUser[msg.sender] -= amountToRedeem;
-        s_ethCollateralPerUser[msg.sender] -= ethToReturn; // Fix: Update collateral mapping
+        s_ethCollateralPerUser[msg.sender] -= ethToReturn;
 
         uint256 healthFactor = getHealthFactor(msg.sender);
         if (healthFactor < MIN_HEALTH_FACTOR) {

--- a/src/sTSLA.sol
+++ b/src/sTSLA.sol
@@ -55,14 +55,11 @@ contract sTSLA is ERC20 {
     }
 
     function redeemAndBurn(uint256 amountToRedeem) external {
-
         // Checks / Effects
         uint256 valueRedeemed = getUsdAmountFromTsla(amountToRedeem);
         uint256 ethToReturn = getEthAmountFromUsd(valueRedeemed);
-
         s_tslaMintedPerUser[msg.sender] -= amountToRedeem;
         s_ethCollateralPerUser[msg.sender] -= ethToReturn;
-
         uint256 healthFactor = getHealthFactor(msg.sender);
         if (healthFactor < MIN_HEALTH_FACTOR) {
             revert sTSLA_feeds__InsufficientCollateral();

--- a/src/sTSLA.sol
+++ b/src/sTSLA.sol
@@ -54,11 +54,15 @@ contract sTSLA is ERC20 {
         // No external interactions
     }
 
-    function redeemAndBurn(uint256 amountToRedeem) external {
+    function redeemAndBurn(uint256 amountToRedeem) external {git add contracts/sTSLA.sol
+
         // Checks / Effects
         uint256 valueRedeemed = getUsdAmountFromTsla(amountToRedeem);
         uint256 ethToReturn = getEthAmountFromUsd(valueRedeemed);
+
         s_tslaMintedPerUser[msg.sender] -= amountToRedeem;
+        s_ethCollateralPerUser[msg.sender] -= ethToReturn; // Fix: Update collateral mapping
+
         uint256 healthFactor = getHealthFactor(msg.sender);
         if (healthFactor < MIN_HEALTH_FACTOR) {
             revert sTSLA_feeds__InsufficientCollateral();


### PR DESCRIPTION
This PR fixes issue **[#19](https://github.com/PatrickAlphaC/rwa-creator/issues/19)** by updating the collateral mapping (`s_ethCollateralPerUser`) when a user redeems and burns synthetic tokens (`sTSLA`).  

#### **Changes Made:**
- Updated `redeemAndBurn(uint256 amountToRedeem)` function to correctly adjust the ETH collateral mapping.  
- This prevents an overestimation of user collateral, ensuring accurate health factor calculations.  

#### **Code Fix:**
**Before:**
```solidity
s_tslaMintedPerUser[msg.sender] -= amountToRedeem;
```
**After:**
```solidity
s_tslaMintedPerUser[msg.sender] -= amountToRedeem;
s_ethCollateralPerUser[msg.sender] -= ethToReturn; // Fix: Update collateral mapping
```

#### **Impact:**
- Fixes a potential inconsistency that could lead to incorrect liquidation thresholds. 
