### PR TITLE
fix: correct precision handling in getEthAmountFromUsd

### DIFF
--- a/src/sTSLA.sol
+++ b/src/sTSLA.sol
@@ -94,7 +94,7 @@ contract sTSLA is ERC20 {
     function getEthAmountFromUsd(uint256 usdAmountInWei) public view returns (uint256) {
         AggregatorV3Interface priceFeed = AggregatorV3Interface(i_ethUsdFeed);
         (, int256 price,,,) = priceFeed.staleCheckLatestRoundData();
-        return (usdAmountInWei * PRECISION) / ((uint256(price) * ADDITIONAL_FEED_PRECISION) * PRECISION);
+        return (usdAmountInWei * PRECISION) / ((uint256(price) * ADDITIONAL_FEED_PRECISION));
     }
 
     function getAccountInformationValue(address user)


### PR DESCRIPTION
The function getEthAmountFromUsd in the contract applies an extra PRECISION factor in the denominator, leading to incorrect ETH amount calculations.
